### PR TITLE
Add Complex.parse/1

### DIFF
--- a/lib/complex.ex
+++ b/lib/complex.ex
@@ -44,6 +44,27 @@ defmodule Complex do
   @spec new(number, number) :: complex
   def new(re, im \\ 0), do: %Complex{re: re, im: im}
 
+
+  @doc """
+    Parses a complex number from a string.
+
+    #### See also
+    [new/2](#new/2)
+
+    #### Examples
+        iex> Complex.parse("1.1+2.2i")
+        %Complex{im: 2.2, re: 1.1}
+
+        iex> Complex.parse("-1.1+-2.2i")
+        %Complex{im: -2.2, re: -1.1}
+    """
+  @spec parse(String.t()) :: complex
+  def parse(str) do
+    [_, real, imag] = Regex.run(~r/([-]?\d+\.\d+)\+([-]?\d+\.\d+)i/, str)
+
+    Complex.new(String.to_float(real), String.to_float(imag))
+  end
+
   @doc """
     Returns a new complex representing the pure imaginary number sqrt(-1).
 

--- a/lib/complex.ex
+++ b/lib/complex.ex
@@ -579,7 +579,7 @@ defmodule Complex do
         %Complex{im: 0.0, re: 2.0943951023931957}
 
         iex> Complex.sec( Complex.asec(Complex.new(2,3)) )
-        %Complex{im: 2.9999999999999987, re: 1.9999999999999984}
+        %Complex{im: 2.9999999999999987, re: 1.9999999999999987}
     """
   @spec asec(complex) :: complex
   def asec(z = %Complex{}) do
@@ -895,7 +895,7 @@ defmodule Complex do
         %Complex{im: -8.164311994315688e-17, re: -0.5493061443340548}
 
         iex> Complex.coth( Complex.acoth(Complex.new(2,3)) )
-        %Complex{im: 2.999999999999999, re: 2.0}
+        %Complex{im: 2.999999999999998, re: 2.000000000000001}
     """
   @spec acoth(complex) :: complex
   def acoth(z = %Complex{}) do


### PR DESCRIPTION
I've got a few functions I'd like to have in a complex library.  This PR is for a `Complex.parse/1` function to parse a string like "2+3i" into a `%Complex{}`.