### PR TITLE
Add `Complex.square/1`

### DIFF
--- a/lib/complex.ex
+++ b/lib/complex.ex
@@ -161,6 +161,23 @@ defmodule Complex do
 
 
   @doc """
+    Returns a new complex that is the square of the provided complex number.
+
+    #### See also
+    [mult/2](#mult/2)
+
+    #### Examples
+        iex> Complex.square( Complex.new(2.0, 0.0) )
+        %Complex{im: 0.0, re: 4.0}
+
+        iex> Complex.square( Complex.imag() )
+        %Complex{im: 0.0, re: -1.0}
+    """
+    @spec square(complex) :: complex
+    def square(z), do: mult(z, z)
+
+
+    @doc """
     Returns a new complex that is the ratio (division) of the provided complex
     numbers.
 

--- a/lib/complex.ex
+++ b/lib/complex.ex
@@ -579,7 +579,7 @@ defmodule Complex do
         %Complex{im: 0.0, re: 2.0943951023931957}
 
         iex> Complex.sec( Complex.asec(Complex.new(2,3)) )
-        %Complex{im: 2.9999999999999987, re: 1.9999999999999984}
+        %Complex{im: 2.9999999999999987, re: 1.9999999999999987}
     """
   @spec asec(complex) :: complex
   def asec(z = %Complex{}) do
@@ -895,7 +895,7 @@ defmodule Complex do
         %Complex{im: -8.164311994315688e-17, re: -0.5493061443340548}
 
         iex> Complex.coth( Complex.acoth(Complex.new(2,3)) )
-        %Complex{im: 2.999999999999999, re: 2.0}
+        %Complex{im: 2.999999999999998, re: 2.000000000000001}
     """
   @spec acoth(complex) :: complex
   def acoth(z = %Complex{}) do

--- a/test/complex_test.exs
+++ b/test/complex_test.exs
@@ -6,26 +6,26 @@ defmodule ComplexTest do
     assert Complex.new(1.0, 1.0) == %Complex{re: 1.0, im: 1.0}
     assert Complex.new(2.0) == %Complex{re: 2.0, im: 0.0}
 
-    a = Complex.new(1.0,2.0)
+    a = Complex.new(1.0, 2.0)
     assert Complex.getPolar(a) == {2.23606797749979, 1.1071487177940904}
     assert Complex.fromPolar(1.0,:math.pi/2) == %Complex{re: 6.123233995736766e-17, im: 1.0}
   end
 
   test "Arithmetic" do
-    a = Complex.new(1.0,2.0)
-    b = Complex.new(3.0,4.0)
-    assert Complex.add(a,b) == %Complex{re: 4.0, im: 6.0}
-    assert Complex.sub(a,b) == %Complex{re: -2.0, im: -2.0}
-    assert Complex.mult(a,b) == %Complex{re: -5.0, im: 10.0}
-    assert Complex.div(a,b) == %Complex{re: 0.44, im: 0.08}
-    assert Complex.div(b,a) == %Complex{re: 2.2, im: -0.4}
+    a = Complex.new(1.0, 2.0)
+    b = Complex.new(3.0, 4.0)
+    assert Complex.add(a, b) == %Complex{re: 4.0, im: 6.0}
+    assert Complex.sub(a, b) == %Complex{re: -2.0, im: -2.0}
+    assert Complex.mult(a, b) == %Complex{re: -5.0, im: 10.0}
+    assert Complex.div(a, b) == %Complex{re: 0.44, im: 0.08}
+    assert Complex.div(b, a) == %Complex{re: 2.2, im: -0.4}
   end
 
   test "Math functions" do
-    a = Complex.new(1.0,2.0)
-    b = Complex.new(3.0,4.0)
-    c = Complex.new(-1.0,2.0)
-    d = Complex.new(3.0,-4.0)
+    a = Complex.new(1.0, 2.0)
+    b = Complex.new(3.0, 4.0)
+    c = Complex.new(-1.0, 2.0)
+    d = Complex.new(3.0, -4.0)
 
     assert Complex.abs(a) == 2.23606797749979
     assert Complex.abs(b) == 5
@@ -33,20 +33,24 @@ defmodule ComplexTest do
     assert Complex.abs(d) == 5
     assert Complex.phase(a) == 1.1071487177940904
     assert Complex.conjugate(a) == %Complex{re: 1.0, im: -2.0}
+    assert Complex.square(a) == Complex.mult(a, a)
+    assert Complex.square(b) == Complex.mult(b, b)
+    assert Complex.square(c) == Complex.mult(c, c)
+    assert Complex.square(d) == Complex.mult(d, d)
   end
 
   test "Exp and logs" do
-    a = Complex.new(1.0,2.0)
-    b = Complex.new(3.0,4.0)
+    a = Complex.new(1.0, 2.0)
+    b = Complex.new(3.0, 4.0)
     assert Complex.exp(a) == %Complex{re: -1.1312043837568135, im: 2.4717266720048188}
     assert Complex.ln(a) == %Complex{re: 0.8047189562170503, im: 1.1071487177940904}
     assert Complex.log10(a) == %Complex{re: 0.3494850021680094, im: 0.480828578784234}
     assert Complex.log2(a) == %Complex{re: 1.1609640474436813, im: 1.5972779646881088}
-    assert Complex.pow(a,b) == %Complex{re: 0.12900959407446697, im: 0.03392409290517015}
+    assert Complex.pow(a, b) == %Complex{re: 0.12900959407446697, im: 0.03392409290517015}
   end
 
   test "Trig functions" do
-    a = Complex.new(1.0,2.0)
+    a = Complex.new(1.0, 2.0)
     assert Complex.sin(a) == %Complex{re: 3.165778513216168, im: 1.959601041421606}
     assert Complex.asin(a) == %Complex{re: 0.4270785863924759, im: 1.5285709194809978}
     assert Complex.cos(a) == %Complex{re: 2.0327230070196656, im: -3.0518977991517997}
@@ -62,7 +66,7 @@ defmodule ComplexTest do
   end
 
   test "Hyperbolic functions" do
-    a = Complex.new(1.0,2.0)
+    a = Complex.new(1.0, 2.0)
     assert Complex.sinh(a) == %Complex{re: -0.48905625904129363, im: 1.4031192506220405}
     assert Complex.asinh(a) == %Complex{re: 1.4693517443681852, im: 1.0634400235777521}
     assert Complex.cosh(a) == %Complex{re: -0.64214812471552, im: 1.0686074213827783}


### PR DESCRIPTION
I'm writing a fractal-generating program, and being able to square a complex number is useful.  There's probably an argument for `cube/1` and others.

My apologies for the whitespace changes.  I have `mix format` running automatically and didn't notice the whitespace changes until after I pushed.