### PR TITLE
Add `Complex.abs_squared/1`.

### DIFF
--- a/lib/complex.ex
+++ b/lib/complex.ex
@@ -186,8 +186,7 @@ defmodule Complex do
 
 
   @doc """
-    Returns a new complex that is the magnitude (length)) of the provided complex
-    number.
+    Returns the magnitude (length) of the provided complex number.
 
     #### See also
     [new/2](#new/2), [phase/1](#phase/1)
@@ -209,6 +208,26 @@ defmodule Complex do
     end
   end
 
+
+  @doc """
+  Returns the square of the magnitude of the provided complex number.
+
+  The square of the magnitude is faster to compute---no square roots!
+
+  #### See also
+  [new/2](#new/2), [abs/1](#abs/1)
+
+  #### Examples
+      iex> Complex.abs_squared( Complex.fromPolar(1, :math.pi/2) )
+      1.0
+
+      iex> Complex.abs_squared( Complex.fromPolar(2, :math.pi/2) )
+      4.0
+  """
+  @spec abs_squared(complex) :: number
+  def abs_squared(%Complex{re: r, im: i}) do
+    r * r + i * i
+  end
 
   @doc """
     Returns a new complex that is the complex conjugate of the provided complex

--- a/lib/complex.ex
+++ b/lib/complex.ex
@@ -579,7 +579,7 @@ defmodule Complex do
         %Complex{im: 0.0, re: 2.0943951023931957}
 
         iex> Complex.sec( Complex.asec(Complex.new(2,3)) )
-        %Complex{im: 2.9999999999999987, re: 1.9999999999999984}
+        %Complex{im: 2.9999999999999987, re: 1.9999999999999987}
     """
   @spec asec(complex) :: complex
   def asec(z = %Complex{}) do
@@ -895,7 +895,7 @@ defmodule Complex do
         %Complex{im: -8.164311994315688e-17, re: -0.5493061443340548}
 
         iex> Complex.coth( Complex.acoth(Complex.new(2,3)) )
-        %Complex{im: 2.999999999999999, re: 2.0}
+        %Complex{im: 2.999999999999998, re: 2.000000000000001}
     """
   @spec acoth(complex) :: complex
   def acoth(z = %Complex{}) do

--- a/test/complex_test.exs
+++ b/test/complex_test.exs
@@ -31,6 +31,10 @@ defmodule ComplexTest do
     assert Complex.abs(b) == 5
     assert Complex.abs(c) == 2.23606797749979
     assert Complex.abs(d) == 5
+    assert Complex.abs_squared(a) == 5
+    assert Complex.abs_squared(b) == 25
+    assert Complex.abs_squared(c) == 5
+    assert Complex.abs_squared(d) == 25
     assert Complex.phase(a) == 1.1071487177940904
     assert Complex.conjugate(a) == %Complex{re: 1.0, im: -2.0}
   end


### PR DESCRIPTION
I'm computing fractals using escape algorithms, and on each iteration for each point, I compare against a cutoff value.  If the magnitude is larger than the cutoff value, the point "escapes" from the fractal, and it gets a pretty color.

It's _much_ cheaper, though, to avoid the square root computation and just simply square the cutoff value.  That's why I'd like `abs_squared`---to avoid the square root computation.