### PR TITLE
Add Complex.real and Complex.imag

### DIFF
--- a/lib/complex.ex
+++ b/lib/complex.ex
@@ -457,6 +457,54 @@ defmodule Complex do
   end
 
   @doc """
+  Returns the real part of the provided complex number.
+
+  ### See also
+
+  `imag/1`
+
+  ### Examples
+
+      iex> Complex.real(Complex.new(1, 2))
+      1.0
+
+      iex> Complex.real(1)
+      1
+  """
+  @spec real(t) :: number
+  @spec real(number) :: number
+  def real(z)
+
+  def real(n) when is_number(n), do: n
+
+  def real(%Complex{re: r, im: _i}), do: r
+
+  @doc """
+  Returns the imaginary part of the provided complex number.
+  If a real number is provided, 0 is returned.
+
+  ### See also
+
+  `real/1`
+
+  ### Examples
+
+      iex> Complex.imag(Complex.new(1, 2))
+      2.0
+
+      iex> Complex.imag(1)
+      0
+  """
+
+  @spec imag(t) :: number
+  @spec imag(number) :: number
+  def imag(z)
+
+  def imag(n) when is_number(n), do: 0
+
+  def imag(%Complex{re: _r, im: i}), do: i
+
+  @doc """
   Returns a new complex that is the complex conjugate of the provided complex
   number.
 

--- a/lib/complex.ex
+++ b/lib/complex.ex
@@ -500,7 +500,7 @@ defmodule Complex do
   @spec imag(number) :: number
   def imag(z)
 
-  def imag(n) when is_number(n), do: 0
+  def imag(n) when is_number(n), do: n * 0
 
   def imag(%Complex{re: _r, im: i}), do: i
 

--- a/test/complex_test.exs
+++ b/test/complex_test.exs
@@ -63,6 +63,14 @@ defmodule ComplexTest do
     assert_close Complex.abs_squared(b), 25
     assert_close Complex.abs_squared(c), 5
     assert_close Complex.abs_squared(d), 25
+    assert Complex.real(a) == 1
+    assert Complex.real(b) == 3.0
+    assert Complex.real(c) == -1.0
+    assert Complex.real(d) == 3.0
+    assert Complex.imag(a) == 2.0
+    assert Complex.imag(b) == 4.0
+    assert Complex.imag(c) == 2.0
+    assert Complex.imag(d) == -4.0
     assert_close Complex.phase(a), 1.1071487177940904
     assert_close Complex.conjugate(a), %Complex{re: 1.0, im: -2.0}
     assert_close Complex.square(a), Complex.multiply(a, a)
@@ -85,6 +93,14 @@ defmodule ComplexTest do
     assert_close Complex.abs_squared(b), 4
     assert_close Complex.abs_squared(c), 9
     assert_close Complex.abs_squared(d), 16
+    assert Complex.real(a) == 1
+    assert Complex.real(b) == 2
+    assert Complex.real(c) == 3
+    assert Complex.real(d) == 4
+    assert Complex.imag(a) == 0
+    assert Complex.imag(b) == 0
+    assert Complex.imag(c) == 0
+    assert Complex.imag(d) == 0
     assert_close Complex.phase(a), 0
     assert_close Complex.phase(-a), :math.pi()
     assert_close Complex.conjugate(a), a


### PR DESCRIPTION
This commit adds the Complex.real and Complex.imag functions,
which return the real and imaginary part of a complex number
respectively.

See https://github.com/elixir-nx/nx/issues/693#issuecomment-1089203385.