### PR TITLE
fix: minor fixes to multiply, phase and parse

### DIFF
--- a/lib/complex.ex
+++ b/lib/complex.ex
@@ -173,6 +173,9 @@ defmodule Complex do
 
       iex> Complex.parse("Inf-NaNi")
       {%Complex{im: :nan, re: :infinity}, ""}
+
+      iex> Complex.parse("Inf")
+      {%Complex{im: 0.0, re: :infinity}, ""}
   """
   @spec parse(String.t()) :: {t, String.t()} | :error
   def parse(str) do
@@ -180,6 +183,12 @@ defmodule Complex do
          {imag_part, tail} <- parse_imag(tail) do
       {new(real_part, multiply(sign_multiplier, imag_part)), tail}
     else
+      {:imag_non_finite, {imag_part, tail}} ->
+        {new(0, imag_part), tail}
+
+      {:real_non_finite, {real_part, tail}} ->
+        {new(real_part, 0), tail}
+
       _ ->
         case parse_imag(str) do
           :error -> :error
@@ -200,6 +209,14 @@ defmodule Complex do
   defp parse_real("NaN-" <> tail), do: {:nan, -1, tail}
   defp parse_real("+NaN-" <> tail), do: {:nan, -1, tail}
   defp parse_real("-NaN-" <> tail), do: {:nan, -1, tail}
+
+  defp parse_real("Infi" <> tail), do: {:imag_non_finite, {:infinity, tail}}
+  defp parse_real("-Infi" <> tail), do: {:imag_non_finite, {:neg_infinity, tail}}
+  defp parse_real("NaNi" <> tail), do: {:imag_non_finite, {:nan, tail}}
+
+  defp parse_real("Inf" <> tail), do: {:real_non_finite, {:infinity, tail}}
+  defp parse_real("-Inf" <> tail), do: {:real_non_finite, {:neg_infinity, tail}}
+  defp parse_real("NaN" <> tail), do: {:real_non_finite, {:nan, tail}}
 
   defp parse_real(str) do
     case Float.parse(str) do
@@ -291,9 +308,14 @@ defmodule Complex do
   def phase(:infinity), do: 0
   def phase(:neg_infinity), do: :math.pi()
 
-  def phase(%Complex{re: :nan, im: im}) when im == 0, do: :nan
-  def phase(%Complex{re: :infinity, im: im}) when im == 0, do: 0
-  def phase(%Complex{re: :neg_infinity, im: im}) when im == 0, do: :math.pi()
+  def phase(%Complex{re: :nan, im: im}) when is_number(im), do: :nan
+  def phase(%Complex{re: :infinity, im: im}) when is_number(im), do: 0
+  def phase(%Complex{re: :neg_infinity, im: im}) when is_number(im), do: :math.pi()
+
+  def phase(%Complex{re: :infinity, im: :infinity}), do: :math.pi()/4
+  def phase(%Complex{re: :infinity, im: :neg_infinity}), do: -:math.pi()/4
+  def phase(%Complex{re: :neg_infinity, im: :infinity}), do: 3*:math.pi()/4
+  def phase(%Complex{re: :neg_infinity, im: :neg_infinity}), do: 5*:math.pi()/4
 
   def phase(%Complex{re: :infinity}), do: :nan
   def phase(%Complex{re: :neg_infinity}), do: :nan
@@ -953,11 +975,11 @@ defmodule Complex do
         divide(new(1.0, 0.0), x)
 
       true ->
-        rho = :math.sqrt(x.re * x.re + x.im * x.im)
-        theta = :math.atan2(x.im, x.re)
-        s = :math.pow(rho, y.re) * :math.exp(-y.im * theta)
-        r = y.re * theta + y.im * :math.log(rho)
-        new(s * :math.cos(r), s * :math.sin(r))
+        rho = abs(x)
+        theta = phase(x)
+        s = multiply(power(rho, y.re), exp(multiply(negate(y.im), theta)))
+        r = add(multiply(y.re, theta), multiply(y.im, ln(rho)))
+        new(multiply(s, cos(r)), multiply(s, sin(r)))
     end
   end
 

--- a/lib/complex.ex
+++ b/lib/complex.ex
@@ -513,7 +513,13 @@ defmodule Complex do
   end
 
   def multiply(%Complex{re: re_l, im: im_l}, %Complex{re: re_r, im: im_r}) when re_r == 0 do
-    new(negate(multiply(im_l, im_r)), multiply(re_l, im_r))
+    re_result =
+      case multiply(im_l, im_r) do
+        result when result == 0 -> 0
+        result -> negate(result)
+      end
+
+    new(re_result, multiply(re_l, im_r))
   end
 
   def multiply(left, right) when is_number(left) and is_number(right), do: left * right

--- a/lib/complex.ex
+++ b/lib/complex.ex
@@ -449,6 +449,9 @@ defmodule Complex do
       iex> Complex.multiply(3, Complex.new(1, 2))
       %Complex{im: 6.0, re: 3.0}
 
+      iex> Complex.multiply(-2, Complex.new(:infinity, :neg_infinity))
+      %Complex{im: :infinity, re: :neg_infinity}
+
   """
   @spec multiply(t | number | non_finite_number, t | number | non_finite_number) ::
           t | number | non_finite_number
@@ -475,7 +478,11 @@ defmodule Complex do
   def multiply(:infinity, :neg_infinity), do: :neg_infinity
   def multiply(:infinity, :infinity), do: :infinity
 
-  def multiply(x, %Complex{re: re, im: im}) when is_non_finite_number(x) do
+  def multiply(x, %Complex{re: re, im: im}) when is_non_finite_number(x) or is_number(x) do
+    new(multiply(re, x), multiply(im, x))
+  end
+
+  def multiply(%Complex{re: re, im: im}, x) when is_non_finite_number(x) or is_number(x) do
     new(multiply(re, x), multiply(im, x))
   end
 

--- a/lib/complex.ex
+++ b/lib/complex.ex
@@ -312,10 +312,10 @@ defmodule Complex do
   def phase(%Complex{re: :infinity, im: im}) when is_number(im), do: 0
   def phase(%Complex{re: :neg_infinity, im: im}) when is_number(im), do: :math.pi()
 
-  def phase(%Complex{re: :infinity, im: :infinity}), do: :math.pi()/4
-  def phase(%Complex{re: :infinity, im: :neg_infinity}), do: -:math.pi()/4
-  def phase(%Complex{re: :neg_infinity, im: :infinity}), do: 3*:math.pi()/4
-  def phase(%Complex{re: :neg_infinity, im: :neg_infinity}), do: 5*:math.pi()/4
+  def phase(%Complex{re: :infinity, im: :infinity}), do: :math.pi() / 4
+  def phase(%Complex{re: :infinity, im: :neg_infinity}), do: -:math.pi() / 4
+  def phase(%Complex{re: :neg_infinity, im: :infinity}), do: 3 * :math.pi() / 4
+  def phase(%Complex{re: :neg_infinity, im: :neg_infinity}), do: 5 * :math.pi() / 4
 
   def phase(%Complex{re: :infinity}), do: :nan
   def phase(%Complex{re: :neg_infinity}), do: :nan
@@ -506,6 +506,14 @@ defmodule Complex do
 
   def multiply(%Complex{re: re, im: im}, x) when is_non_finite_number(x) or is_number(x) do
     new(multiply(re, x), multiply(im, x))
+  end
+
+  def multiply(%Complex{re: re_l, im: im_l}, %Complex{re: re_r, im: im_r}) when im_r == 0 do
+    new(multiply(re_r, re_l), multiply(re_r, im_l))
+  end
+
+  def multiply(%Complex{re: re_l, im: im_l}, %Complex{re: re_r, im: im_r}) when re_r == 0 do
+    new(negate(multiply(im_l, im_r)), multiply(re_l, im_r))
   end
 
   def multiply(left, right) when is_number(left) and is_number(right), do: left * right

--- a/test/complex_test.exs
+++ b/test/complex_test.exs
@@ -327,14 +327,14 @@ defmodule ComplexTest do
       assert Complex.phase(Complex.new(re, im)) == phase
     end
 
-    assert Complex.phase(Complex.new(:infinity, :infinity)) == :math.pi()/4
+    assert Complex.phase(Complex.new(:infinity, :infinity)) == :math.pi() / 4
     assert Complex.phase(Complex.new(:infinity, :nan)) == :nan
-    assert Complex.phase(Complex.new(:infinity, :neg_infinity)) == -:math.pi()/4
+    assert Complex.phase(Complex.new(:infinity, :neg_infinity)) == -:math.pi() / 4
     assert Complex.phase(Complex.new(:infinity, -1)) == 0
     assert Complex.phase(Complex.new(:infinity, 1)) == 0
-    assert Complex.phase(Complex.new(:neg_infinity, :infinity)) == 3*:math.pi()/4
+    assert Complex.phase(Complex.new(:neg_infinity, :infinity)) == 3 * :math.pi() / 4
     assert Complex.phase(Complex.new(:neg_infinity, :nan)) == :nan
-    assert Complex.phase(Complex.new(:neg_infinity, :neg_infinity)) == 5 * :math.pi()/4
+    assert Complex.phase(Complex.new(:neg_infinity, :neg_infinity)) == 5 * :math.pi() / 4
     assert Complex.phase(Complex.new(:neg_infinity, -1)) == :math.pi()
     assert Complex.phase(Complex.new(:neg_infinity, 1)) == :math.pi()
 

--- a/test/complex_test.exs
+++ b/test/complex_test.exs
@@ -45,9 +45,9 @@ defmodule ComplexTest do
     assert {%Complex{re: :infinity, im: :neg_infinity}, tail} == Complex.parse("Inf-Infi" <> tail)
     assert {%Complex{re: :nan, im: :nan}, tail} == Complex.parse("NaN+NaNi" <> tail)
 
-    assert :error == Complex.parse("Inf")
-    assert :error == Complex.parse("-Inf")
-    assert :error == Complex.parse("NaN")
+    assert {%Complex{re: :infinity, im: 0}, tail} == Complex.parse("Inf" <> tail)
+    assert {%Complex{re: :neg_infinity, im: 0}, tail} == Complex.parse("-Inf" <> tail)
+    assert {%Complex{re: :nan, im: 0}, tail} == Complex.parse("NaN" <> tail)
 
     assert {%Complex{re: 0, im: :infinity}, ""} == Complex.parse("Infi")
     assert {%Complex{re: 0, im: :infinity}, ""} == Complex.parse("+Infi")
@@ -327,9 +327,16 @@ defmodule ComplexTest do
       assert Complex.phase(Complex.new(re, im)) == phase
     end
 
-    for re <- [:infinity, :neg_infinity], im <- [:infinity, :nan, :neg_infinity, -1, 1] do
-      assert Complex.phase(Complex.new(re, im)) == :nan
-    end
+    assert Complex.phase(Complex.new(:infinity, :infinity)) == :math.pi()/4
+    assert Complex.phase(Complex.new(:infinity, :nan)) == :nan
+    assert Complex.phase(Complex.new(:infinity, :neg_infinity)) == -:math.pi()/4
+    assert Complex.phase(Complex.new(:infinity, -1)) == 0
+    assert Complex.phase(Complex.new(:infinity, 1)) == 0
+    assert Complex.phase(Complex.new(:neg_infinity, :infinity)) == 3*:math.pi()/4
+    assert Complex.phase(Complex.new(:neg_infinity, :nan)) == :nan
+    assert Complex.phase(Complex.new(:neg_infinity, :neg_infinity)) == 5 * :math.pi()/4
+    assert Complex.phase(Complex.new(:neg_infinity, -1)) == :math.pi()
+    assert Complex.phase(Complex.new(:neg_infinity, 1)) == :math.pi()
 
     assert Complex.phase(Complex.new(1, :infinity)) == :math.pi() / 2
     assert Complex.phase(Complex.new(1, :neg_infinity)) == -:math.pi() / 2


### PR DESCRIPTION
Edge cases caught while adding non-finite support in Nx.BinaryBackend :man_facepalming: 

multiply: Previously `-2 * Inf-Infi` would return `nan+nani` because `-2` would be upcast to `-2+0i`, which ends up messing with `0 * inf`-nans

parse: couldn't handle "Inf" and such

phase: infinities can have phase inferred correctly when not accompanied by nan